### PR TITLE
Fix for degraded InferenceService with condition `Stopped` equals `False`

### DIFF
--- a/components/operators/openshift-gitops/instance/components/health-check-openshift-ai/patch-inferenceservice-health-check.yaml
+++ b/components/operators/openshift-gitops/instance/components/health-check-openshift-ai/patch-inferenceservice-health-check.yaml
@@ -33,11 +33,11 @@
 
             if condition.status == "Unknown" then
               status_unknown = status_unknown + 1
-            elseif condition.status == "False" then
+            elseif condition.status == "False" and condition.type ~= "Stopped" then
               status_false = status_false + 1
             end
 
-            if condition.status ~= "True" then
+            if condition.status ~= "True" and condition.type ~= "Stopped" then
               msg = msg .. i .. ": " .. condition.type .. " | " .. condition.status
               if condition.reason ~= nil and condition.reason ~= "" then
                 msg = msg .. " | " .. condition.reason


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

# What does this PR do?
[Provide a short summary of what this PR does and why. Link to relevant issues if applicable.]

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Checklist
- [ ] You have completed the described test plan and included screenshots in the PR or comments showing the results
- [ ] Relevant documentation has been updated
- [ ] You have squashed commits (including commits to test from your branch) to be logical and reduce unnecessary commits

## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
